### PR TITLE
敵が全員死亡している場合にはコマンドをスキップする機能を追加

### DIFF
--- a/Assets/_CryStar/Runtime/Battle/MVP-C/Execute/ExecutePresenter.cs
+++ b/Assets/_CryStar/Runtime/Battle/MVP-C/Execute/ExecutePresenter.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Cysharp.Threading.Tasks;
 
 namespace CryStar.CommandBattle
@@ -48,6 +49,14 @@ namespace CryStar.CommandBattle
                 if (!entry.Executor.IsAlive)
                 {
                     // 実行者が死亡している場合はスキップ
+                    continue;
+                }
+                
+                // ターゲットが全員死亡しているかチェック
+                bool hasAliveTarget = entry.Targets.Any(t => t.IsAlive);
+                if (!hasAliveTarget)
+                {
+                    // 全ターゲットが死亡している場合はスキップ
                     continue;
                 }
                 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Battle flow now skips commands that have no living targets, preventing wasted turns and avoiding unnecessary delays.
  * Eliminates redundant battle log entries for actions that would have targeted only defeated enemies.
  * Improves round progression when targets are defeated mid-sequence, ensuring smoother and more consistent outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->